### PR TITLE
Fix game mode return types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export type {
 export type { OsuApiV2WebRequestError } from "./helpers/custom_errors"
 
 export { ScoresType } from "./users/scores"
-export { GameMode } from "./types/game_mode"
+export { GameMode, GameModeString } from "./types/game_mode"
 export { GameMods } from "./types/game_mods"
 export { RankedStatus } from "./types/ranked_status"
 

--- a/src/types/beatmap.ts
+++ b/src/types/beatmap.ts
@@ -2,6 +2,7 @@ import { RankedStatus } from "./ranked_status"
 import type { Failtimes } from "./failtimes"
 import type { Timestamp } from "./timestamp"
 import type { User } from "./user"
+import { GameMode, GameModeString } from "./game_mode"
 
 export interface Covers {
     cover: string
@@ -119,7 +120,7 @@ export interface BeatmapCompact {
     difficulty_rating: number
     /** integer */
     id: number
-    mode: string
+    mode: GameModeString
     /**
      * See Rank status for list of possible values.
      */
@@ -171,7 +172,7 @@ export interface Beatmap extends BeatmapCompact {
     is_scoreable: boolean
     last_updated: Timestamp
     /** integer */
-    mode_int: number
+    mode_int: GameMode
     /** integer */
     passcount: number
     /** integer */

--- a/src/types/game_mode.ts
+++ b/src/types/game_mode.ts
@@ -3,6 +3,22 @@
  *
  * https://osu.ppy.sh/docs/index.html#gamemode
  */
+/**
+ * Available game modes:
+ *
+ * https://osu.ppy.sh/docs/index.html#gamemode
+ */
+export enum GameModeString {
+    /** osu!catch */
+    fruits = "fruits",
+    /** osu!mania */
+    mania = "mania",
+    /** osu!standard */
+    osu = "osu",
+    /** osu!taiko */
+    taiko = "taiko",
+}
+
 export enum GameMode {
     /** osu!catch */
     fruits = 2,

--- a/src/types/score.ts
+++ b/src/types/score.ts
@@ -2,7 +2,7 @@ import type { Beatmap } from "./beatmap"
 import type { Timestamp } from "./timestamp"
 import type { User } from "./user"
 
-import { GameMode } from "./game_mode"
+import { GameMode, GameModeString } from "./game_mode"
 import { Beatmapset } from ".."
 
 /**
@@ -47,9 +47,9 @@ export interface Score {
     pp: number
     rank: string
     created_at: Timestamp
-    mode: GameMode
+    mode: GameModeString
     /** integer */
-    mode_int: number
+    mode_int: GameMode
     replay: boolean
     // Optional:
     beatmap?: Beatmap

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,5 @@
 import type { Timestamp } from "./timestamp"
-import { GameMode } from "./game_mode"
+import { GameModeString } from "./game_mode"
 
 export interface UserCompactCover {
     custom_url: null | unknown
@@ -222,7 +222,7 @@ export interface User extends UserCompactBase {
      */
     max_friends: number
     occupation?: string
-    playmode: GameMode
+    playmode: GameModeString
     /**
      * Device choices of the user
      */

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -160,7 +160,7 @@ export interface UserCompactBase {
     page?: unknown
     pending_beatmapset_count?: unknown
     previous_usernames?: unknown
-    rank_history?: unknown
+    rank_history?: UserRankHistory
     ranked_beatmapset_count?: unknown
     replays_watched_counts?: unknown
     scores_best_count?: number
@@ -172,6 +172,11 @@ export interface UserCompactBase {
     unread_pm_count?: unknown
     user_achievements?: UserAchievement[]
     user_preferences?: unknown
+}
+
+export interface UserRankHistory {
+    mode: GameModeString
+    data: number[]
 }
 
 /**

--- a/src/users/name.ts
+++ b/src/users/name.ts
@@ -9,15 +9,15 @@ import { OsuApiV2WebRequestError } from "../helpers/custom_errors"
 
 declare const fetch: Fetch
 
-export const id = async (
+export const name = async (
     oauthAccessToken: OAuthAccessToken,
-    userId: number,
+    userName: string,
     mode?: GameModeString,
 ): Promise<User> => {
     const params = urlParameterGenerator([
         {
             name: "key",
-            value: "id",
+            value: "username ",
         },
     ])
     const method = "get"
@@ -29,7 +29,7 @@ export const id = async (
     // eslint-disable-next-line no-useless-catch
     try {
         const res = await fetch(
-            `${baseUrlApiV2}/users/${userId}${modeString}${params}`,
+            `${baseUrlApiV2}/users/${userName}${modeString}${params}`,
             {
                 headers,
                 method,

--- a/src/users/users.ts
+++ b/src/users/users.ts
@@ -1,9 +1,11 @@
 import { id } from "./id"
+import { name } from "./name"
 import { recentActivity } from "./recentActivity"
 import { scores } from "./scores"
 
 export const users = {
     id,
+    name,
     recentActivity,
     scores,
 }

--- a/test/osu_api_v2/endpoints/beatmaps/check_beatmap.ts
+++ b/test/osu_api_v2/endpoints/beatmaps/check_beatmap.ts
@@ -1,6 +1,11 @@
 import { expect } from "chai"
 import moment from "moment"
-import { Beatmap, GameMode, RankedStatus } from "../../../../src/index"
+import {
+    Beatmap,
+    GameMode,
+    GameModeString,
+    RankedStatus,
+} from "../../../../src/index"
 import { saveOsuResponseObjectAsFile } from "../../../helper.test"
 import { checkBeatmapsetObject } from "./check_beatmapset"
 
@@ -96,6 +101,12 @@ export const checkBeatmapObject = (
             .that.satisfies(Number.isInteger)
     }
     expect(beatmap.mode).to.be.a("string").with.a.lengthOf.greaterThan(0)
+    expect([
+        GameModeString.fruits,
+        GameModeString.mania,
+        GameModeString.osu,
+        GameModeString.taiko,
+    ]).to.include(beatmap.mode)
     expect([
         GameMode[GameMode.fruits],
         GameMode[GameMode.mania],

--- a/test/osu_api_v2/endpoints/users.test.ts
+++ b/test/osu_api_v2/endpoints/users.test.ts
@@ -51,30 +51,6 @@ export const usersTestSuite = (): Suite =>
                 )
                 expect(user.playmode).equals(GameModeString.osu)
             })
-            it("user playmode should equal 'taiko'", async () => {
-                const user = await osuApiV2.users.id(
-                    oauthAccessToken,
-                    9096716,
-                    GameMode.taiko,
-                )
-                expect(user.playmode).equals(GameModeString.taiko)
-            })
-            it("user playmode should equal 'fruits'", async () => {
-                const user = await osuApiV2.users.id(
-                    oauthAccessToken,
-                    9096716,
-                    GameMode.fruits,
-                )
-                expect(user.playmode).equals(GameModeString.fruits)
-            })
-            it("user playmode should equal 'mania'", async () => {
-                const user = await osuApiV2.users.id(
-                    oauthAccessToken,
-                    9096716,
-                    GameMode.mania,
-                )
-                expect(user.playmode).equals(GameModeString.mania)
-            })
         }).timeout(8000)
         it("recentActivity", async () => {
             // Check if the request throws an error when the id is invalid

--- a/test/osu_api_v2/endpoints/users.test.ts
+++ b/test/osu_api_v2/endpoints/users.test.ts
@@ -42,52 +42,143 @@ export const usersTestSuite = (): Suite =>
             })
             it("should make request successfully", async () => {
                 await osuApiV2.users.id(oauthAccessToken, 9096716)
-                await osuApiV2.users.id(oauthAccessToken, 9096716, GameMode.osu)
-                await osuApiV2.users.id(
+                const osu = await osuApiV2.users.id(
                     oauthAccessToken,
                     9096716,
-                    GameMode.taiko,
+                    GameModeString.osu,
                 )
-                await osuApiV2.users.id(
+                const taiko = await osuApiV2.users.id(
                     oauthAccessToken,
                     9096716,
-                    GameMode.fruits,
+                    GameModeString.taiko,
                 )
-                await osuApiV2.users.id(
+                const fruits = await osuApiV2.users.id(
                     oauthAccessToken,
                     9096716,
-                    GameMode.mania,
+                    GameModeString.fruits,
                 )
+                const mania = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameModeString.mania,
+                )
+                if (fruits.rank_history?.mode !== undefined) {
+                    expect(fruits.rank_history?.mode).equals(
+                        GameModeString.fruits,
+                    )
+                }
+                if (taiko.rank_history?.mode !== undefined) {
+                    expect(taiko.rank_history?.mode).equals(
+                        GameModeString.taiko,
+                    )
+                }
+                if (mania.rank_history?.mode !== undefined) {
+                    expect(mania.rank_history?.mode).equals(
+                        GameModeString.mania,
+                    )
+                }
+                if (osu.rank_history?.mode !== undefined) {
+                    expect(osu.rank_history?.mode).equals(GameModeString.osu)
+                }
             }).timeout(8000)
             it("user playmode should equal 'osu'", async () => {
-                const user = await osuApiV2.users.id(
-                    oauthAccessToken,
-                    9096716,
-                    GameMode.taiko,
-                )
+                const user = await osuApiV2.users.id(oauthAccessToken, 9096716)
                 expect(user.playmode).equals(GameModeString.osu)
             })
             it("user playmode should equal 'taiko'", async () => {
-                const user = await osuApiV2.users.id(
+                const user = await osuApiV2.users.id(oauthAccessToken, 8741695)
+                expect(user.playmode).equals(GameModeString.taiko)
+            })
+            it("user playmode should equal 'fruits'", async () => {
+                const user = await osuApiV2.users.id(oauthAccessToken, 4158549)
+                expect(user.playmode).equals(GameModeString.fruits)
+            })
+            it("user playmode should equal 'mania'", async () => {
+                const user = await osuApiV2.users.id(oauthAccessToken, 758406)
+                expect(user.playmode).equals(GameModeString.mania)
+            })
+        }).timeout(8000)
+        describe("name", () => {
+            it("should throw name name is '-1'", async () => {
+                // Check if the request throws an error when the name is "-1"
+                let errorInvalidBeatmapId: OsuApiV2WebRequestError | null = null
+                try {
+                    const result = await osuApiV2.users.name(
+                        oauthAccessToken,
+                        "-1",
+                    )
+                    console.log(result)
+                } catch (err) {
+                    errorInvalidBeatmapId = err as OsuApiV2WebRequestError
+                }
+                checkOsuApiV2WebRequestError(
+                    errorInvalidBeatmapId,
+                    OsuApiV2WebRequestErrorType.NOT_FOUND,
+                )
+            })
+            it("should make request successfully", async () => {
+                await osuApiV2.users.name(oauthAccessToken, "Ooi")
+                const osu = await osuApiV2.users.name(
                     oauthAccessToken,
-                    8741695,
-                    GameMode.fruits,
+                    "Ooi",
+                    GameModeString.osu,
+                )
+                const taiko = await osuApiV2.users.name(
+                    oauthAccessToken,
+                    "Ooi",
+                    GameModeString.taiko,
+                )
+                const fruits = await osuApiV2.users.name(
+                    oauthAccessToken,
+                    "Ooi",
+                    GameModeString.fruits,
+                )
+                const mania = await osuApiV2.users.name(
+                    oauthAccessToken,
+                    "Ooi",
+                    GameModeString.mania,
+                )
+                if (fruits.rank_history?.mode !== undefined) {
+                    expect(fruits.rank_history?.mode).equals(
+                        GameModeString.fruits,
+                    )
+                }
+                if (taiko.rank_history?.mode !== undefined) {
+                    expect(taiko.rank_history?.mode).equals(
+                        GameModeString.taiko,
+                    )
+                }
+                if (mania.rank_history?.mode !== undefined) {
+                    expect(mania.rank_history?.mode).equals(
+                        GameModeString.mania,
+                    )
+                }
+                if (osu.rank_history?.mode !== undefined) {
+                    expect(osu.rank_history?.mode).equals(GameModeString.osu)
+                }
+            }).timeout(8000)
+            it("user playmode should equal 'osu'", async () => {
+                const user = await osuApiV2.users.name(oauthAccessToken, "Ooi")
+                expect(user.playmode).equals(GameModeString.osu)
+            })
+            it("user playmode should equal 'taiko'", async () => {
+                const user = await osuApiV2.users.name(
+                    oauthAccessToken,
+                    "syaron105",
                 )
                 expect(user.playmode).equals(GameModeString.taiko)
             })
             it("user playmode should equal 'fruits'", async () => {
-                const user = await osuApiV2.users.id(
+                const user = await osuApiV2.users.name(
                     oauthAccessToken,
-                    4158549,
-                    GameMode.mania,
+                    "YesMyDarknesss",
                 )
                 expect(user.playmode).equals(GameModeString.fruits)
             })
             it("user playmode should equal 'mania'", async () => {
-                const user = await osuApiV2.users.id(
+                const user = await osuApiV2.users.name(
                     oauthAccessToken,
-                    758406,
-                    GameMode.osu,
+                    "dressurf",
                 )
                 expect(user.playmode).equals(GameModeString.mania)
             })

--- a/test/osu_api_v2/endpoints/users.test.ts
+++ b/test/osu_api_v2/endpoints/users.test.ts
@@ -1,6 +1,8 @@
+import { expect } from "chai"
 import { before, describe, it, Suite } from "mocha"
 import osuApiV2, {
     GameMode,
+    GameModeString,
     OAuthAccessToken,
     OsuApiV2WebRequestError,
 } from "../../../src/index"
@@ -24,22 +26,55 @@ export const usersTestSuite = (): Suite =>
             )
         })
 
-        it("id", async () => {
-            // Check if the request throws an error when the id is invalid
-            let errorInvalidBeatmapId: OsuApiV2WebRequestError | null = null
-            try {
-                await osuApiV2.users.id(oauthAccessToken, -9096716)
-            } catch (err) {
-                errorInvalidBeatmapId = err as OsuApiV2WebRequestError
-            }
-            checkOsuApiV2WebRequestError(
-                errorInvalidBeatmapId,
-                OsuApiV2WebRequestErrorType.NOT_FOUND,
-            )
-
-            await osuApiV2.users.id(oauthAccessToken, 9096716)
-            await osuApiV2.users.id(oauthAccessToken, 9096716, GameMode.osu)
-            await osuApiV2.users.id(oauthAccessToken, 9096716, GameMode.mania)
+        describe("id", () => {
+            it("should throw if id is invalid", async () => {
+                // Check if the request throws an error when the id is invalid
+                let errorInvalidBeatmapId: OsuApiV2WebRequestError | null = null
+                try {
+                    await osuApiV2.users.id(oauthAccessToken, -9096716)
+                } catch (err) {
+                    errorInvalidBeatmapId = err as OsuApiV2WebRequestError
+                }
+                checkOsuApiV2WebRequestError(
+                    errorInvalidBeatmapId,
+                    OsuApiV2WebRequestErrorType.NOT_FOUND,
+                )
+            })
+            it("should make request successfully", async () => {
+                await osuApiV2.users.id(oauthAccessToken, 9096716)
+            })
+            it("user playmode should equal 'osu'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.osu,
+                )
+                expect(user.playmode).equals(GameModeString.osu)
+            })
+            it("user playmode should equal 'taiko'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.taiko,
+                )
+                expect(user.playmode).equals(GameModeString.taiko)
+            })
+            it("user playmode should equal 'fruits'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.fruits,
+                )
+                expect(user.playmode).equals(GameModeString.fruits)
+            })
+            it("user playmode should equal 'mania'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.mania,
+                )
+                expect(user.playmode).equals(GameModeString.mania)
+            })
         }).timeout(8000)
         it("recentActivity", async () => {
             // Check if the request throws an error when the id is invalid

--- a/test/osu_api_v2/endpoints/users.test.ts
+++ b/test/osu_api_v2/endpoints/users.test.ts
@@ -42,14 +42,54 @@ export const usersTestSuite = (): Suite =>
             })
             it("should make request successfully", async () => {
                 await osuApiV2.users.id(oauthAccessToken, 9096716)
-            })
+                await osuApiV2.users.id(oauthAccessToken, 9096716, GameMode.osu)
+                await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.taiko,
+                )
+                await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.fruits,
+                )
+                await osuApiV2.users.id(
+                    oauthAccessToken,
+                    9096716,
+                    GameMode.mania,
+                )
+            }).timeout(8000)
             it("user playmode should equal 'osu'", async () => {
                 const user = await osuApiV2.users.id(
                     oauthAccessToken,
                     9096716,
-                    GameMode.osu,
+                    GameMode.taiko,
                 )
                 expect(user.playmode).equals(GameModeString.osu)
+            })
+            it("user playmode should equal 'taiko'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    8741695,
+                    GameMode.fruits,
+                )
+                expect(user.playmode).equals(GameModeString.taiko)
+            })
+            it("user playmode should equal 'fruits'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    4158549,
+                    GameMode.mania,
+                )
+                expect(user.playmode).equals(GameModeString.fruits)
+            })
+            it("user playmode should equal 'mania'", async () => {
+                const user = await osuApiV2.users.id(
+                    oauthAccessToken,
+                    758406,
+                    GameMode.osu,
+                )
+                expect(user.playmode).equals(GameModeString.mania)
             })
         }).timeout(8000)
         it("recentActivity", async () => {


### PR DESCRIPTION
The return type of user.playmode and beatmap.mode is `string`.

Added a new enum for the string values so that the interfaces match what you actually get from the API.