### PR TITLE
Mask header string from error to prevent secrets leaking

### DIFF
--- a/src/helpers/custom_errors.ts
+++ b/src/helpers/custom_errors.ts
@@ -25,7 +25,11 @@ export class OsuApiV2WebRequestError extends Error {
         this.statusText = statusText
         this.url = url
         this.method = method
-        this.headers = headers
+        this.headers = {
+            ...headers,
+            authorization:
+                headers.authorization.substring(0, 20) + "***redacted***",
+        }
         if (body !== undefined) {
             this.body = body
         }

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -50,7 +50,7 @@ export const checkOsuApiV2WebRequestError = (
     }
 }
 
-describe.only("OsuApiV2WebRequestError", () => {
+describe("OsuApiV2WebRequestError", () => {
     it("should mask the authorization header", () => {
         const error = new OsuApiV2WebRequestError(
             "message",

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -50,6 +50,23 @@ export const checkOsuApiV2WebRequestError = (
     }
 }
 
+describe.only("OsuApiV2WebRequestError", () => {
+    it("should mask the authorization header", () => {
+        const error = new OsuApiV2WebRequestError(
+            "message",
+            400,
+            "text",
+            "someUrl",
+            "get",
+            { authorization: "Bearer 098304982039482039482304829034820934" },
+        )
+
+        expect(error.headers.authorization).equals(
+            "Bearer 0983049820394***redacted***",
+        )
+    })
+})
+
 describe("helper", async () => {
     it("urlParameterGenerator", async () => {
         const paramGeneratorEmpty = urlParameterGenerator()


### PR DESCRIPTION
When an error is returned by the osu API, the error containing a JWT token will be logged to the console, or even worse, may be returned to a client (if you do not perform proper error handling).

It is a good practise to not log secret values for security reasons.

This allows you to see the first 20 characters of the authorization header, but masks the rest, which allows you to debug your code but also doesn't leak the secret.