### PR TITLE
Export OsuApiV2WebRequestError as value instead of type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export type {
     UserCompactKusodo,
     User,
 } from "./types/user"
-export type { OsuApiV2WebRequestError } from "./helpers/custom_errors"
+export { OsuApiV2WebRequestError } from "./helpers/custom_errors"
 
 export { ScoresType } from "./users/scores"
 export { GameMode, GameModeInt } from "./types/game_mode"


### PR DESCRIPTION
Since the error class was export as a type, it wasn't possible to check for an instance of the class (e.g. in a try/catch block)

Example of error caused by exporting this as a type:
![image](https://user-images.githubusercontent.com/12624925/191085224-fb2c499f-ad1e-4db4-bb50-14a41d3dccdc.png)
