### PR TITLE
Add authorization code grant

### DIFF
--- a/src/oauth/authorization_code_grant.ts
+++ b/src/oauth/authorization_code_grant.ts
@@ -1,0 +1,51 @@
+import type { OauthAccessTokenWithRefresh } from "../types/oauth_access_token"
+import type { Fetch } from "../types/fetch"
+
+import { baseUrl } from "../types/api_info"
+import { OsuApiV2WebRequestError } from "../helpers/custom_errors"
+import { AuthorizationCodeGrant } from "../types/authorization_code_grant"
+
+declare const fetch: Fetch
+
+export const authorizationCodeGrant = async (
+    client_id: number,
+    client_secret: string,
+    redirect_uri: string,
+    code: string,
+): Promise<OauthAccessTokenWithRefresh> => {
+    const requestBody: AuthorizationCodeGrant = {
+        client_id,
+        client_secret,
+        code,
+        grant_type: "authorization_code",
+        redirect_uri,
+    }
+    const method = "post"
+    const headers = { "Content-Type": "application/json" }
+    const body = JSON.stringify(requestBody)
+    // eslint-disable-next-line no-useless-catch
+    try {
+        const res = await fetch(`${baseUrl}/oauth/token`, {
+            body,
+            headers,
+            method,
+        })
+        if (res.status !== 200) {
+            throw new OsuApiV2WebRequestError(
+                `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
+                res.status,
+                res.statusText,
+                res.url,
+                method,
+                headers,
+                body,
+            )
+        }
+
+        const oauthAccessToken =
+            (await res.json()) as OauthAccessTokenWithRefresh
+        return oauthAccessToken
+    } catch (err) {
+        throw err
+    }
+}

--- a/src/oauth/authorization_code_grant.ts
+++ b/src/oauth/authorization_code_grant.ts
@@ -23,29 +23,23 @@ export const authorizationCodeGrant = async (
     const method = "post"
     const headers = { "Content-Type": "application/json" }
     const body = JSON.stringify(requestBody)
-    // eslint-disable-next-line no-useless-catch
-    try {
-        const res = await fetch(`${baseUrl}/oauth/token`, {
-            body,
-            headers,
+    const res = await fetch(`${baseUrl}/oauth/token`, {
+        body,
+        headers,
+        method,
+    })
+    if (res.status !== 200) {
+        throw new OsuApiV2WebRequestError(
+            `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
+            res.status,
+            res.statusText,
+            res.url,
             method,
-        })
-        if (res.status !== 200) {
-            throw new OsuApiV2WebRequestError(
-                `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
-                res.status,
-                res.statusText,
-                res.url,
-                method,
-                headers,
-                body,
-            )
-        }
-
-        const oauthAccessToken =
-            (await res.json()) as OauthAccessTokenWithRefresh
-        return oauthAccessToken
-    } catch (err) {
-        throw err
+            headers,
+            body,
+        )
     }
+
+    const oauthAccessToken = (await res.json()) as OauthAccessTokenWithRefresh
+    return oauthAccessToken
 }

--- a/src/oauth/authorization_code_grant.ts
+++ b/src/oauth/authorization_code_grant.ts
@@ -36,7 +36,10 @@ export const authorizationCodeGrant = async (
             res.url,
             method,
             headers,
-            body,
+            JSON.stringify({
+                ...requestBody,
+                client_secret: "[redacted]",
+            }),
         )
     }
 

--- a/src/oauth/client_credentials_grant.ts
+++ b/src/oauth/client_credentials_grant.ts
@@ -34,7 +34,10 @@ export const clientCredentialsGrant = async (
             res.url,
             method,
             headers,
-            body,
+            JSON.stringify({
+                ...requestBody,
+                client_secret: "[redacted]",
+            }),
         )
     }
 

--- a/src/oauth/oauth.ts
+++ b/src/oauth/oauth.ts
@@ -1,5 +1,7 @@
 import { clientCredentialsGrant } from "./client_credentials_grant"
+import { authorizationCodeGrant } from "./authorization_code_grant"
 
 export const oauth = {
+    authorizationCodeGrant,
     clientCredentialsGrant,
 }

--- a/src/oauth/refresh_token_grant.ts
+++ b/src/oauth/refresh_token_grant.ts
@@ -23,29 +23,24 @@ export const refreshTokenGrant = async (
     const method = "post"
     const headers = { "Content-Type": "application/json" }
     const body = JSON.stringify(requestBody)
-    // eslint-disable-next-line no-useless-catch
-    try {
-        const res = await fetch(`${baseUrl}/oauth/token`, {
-            body,
-            headers,
-            method,
-        })
-        if (res.status !== 200) {
-            throw new OsuApiV2WebRequestError(
-                `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
-                res.status,
-                res.statusText,
-                res.url,
-                method,
-                headers,
-                body,
-            )
-        }
 
-        const oauthAccessToken =
-            (await res.json()) as OauthAccessTokenWithRefresh
-        return oauthAccessToken
-    } catch (err) {
-        throw err
+    const res = await fetch(`${baseUrl}/oauth/token`, {
+        body,
+        headers,
+        method,
+    })
+    if (res.status !== 200) {
+        throw new OsuApiV2WebRequestError(
+            `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
+            res.status,
+            res.statusText,
+            res.url,
+            method,
+            headers,
+            body,
+        )
     }
+
+    const oauthAccessToken = (await res.json()) as OauthAccessTokenWithRefresh
+    return oauthAccessToken
 }

--- a/src/oauth/refresh_token_grant.ts
+++ b/src/oauth/refresh_token_grant.ts
@@ -1,0 +1,51 @@
+import type { OauthAccessTokenWithRefresh } from "../types/oauth_access_token"
+import type { Fetch } from "../types/fetch"
+
+import { baseUrl } from "../types/api_info"
+import { OsuApiV2WebRequestError } from "../helpers/custom_errors"
+import { RefreshTokenGrant } from "../types/refresh_token_grant"
+
+declare const fetch: Fetch
+
+export const refreshTokenGrant = async (
+    client_id: number,
+    client_secret: string,
+    redirect_uri: string,
+    refresh_token: string,
+): Promise<OauthAccessTokenWithRefresh> => {
+    const requestBody: RefreshTokenGrant = {
+        client_id,
+        client_secret,
+        grant_type: "refresh_token",
+        redirect_uri,
+        refresh_token,
+    }
+    const method = "post"
+    const headers = { "Content-Type": "application/json" }
+    const body = JSON.stringify(requestBody)
+    // eslint-disable-next-line no-useless-catch
+    try {
+        const res = await fetch(`${baseUrl}/oauth/token`, {
+            body,
+            headers,
+            method,
+        })
+        if (res.status !== 200) {
+            throw new OsuApiV2WebRequestError(
+                `Bad web request (${res.status}=${res.statusText}, url=${res.url})`,
+                res.status,
+                res.statusText,
+                res.url,
+                method,
+                headers,
+                body,
+            )
+        }
+
+        const oauthAccessToken =
+            (await res.json()) as OauthAccessTokenWithRefresh
+        return oauthAccessToken
+    } catch (err) {
+        throw err
+    }
+}

--- a/src/oauth/refresh_token_grant.ts
+++ b/src/oauth/refresh_token_grant.ts
@@ -37,7 +37,10 @@ export const refreshTokenGrant = async (
             res.url,
             method,
             headers,
-            body,
+            JSON.stringify({
+                ...requestBody,
+                client_secret: "[redacted]",
+            }),
         )
     }
 

--- a/src/types/authorization_code_grant.ts
+++ b/src/types/authorization_code_grant.ts
@@ -1,0 +1,28 @@
+/**
+ * This exchanges a code retrieved by a user (through OAuth signin) for a bearer token.
+ * The process of obtaining a code is outside the scope of this library (See docs for more information)
+ *
+ * https://osu.ppy.sh/docs/index.html#authorization-code-grant
+ */
+export interface AuthorizationCodeGrant {
+    /**
+     * The Client ID you received when you registered
+     */
+    client_id: number
+    /**
+     * The client secret of your application
+     */
+    client_secret: string
+    /**
+     * This must always be authorization_code (or refresh_token)
+     */
+    grant_type: "authorization_code"
+    /**
+     * This must match the redirect_uri of your app when you registered it
+     */
+    redirect_uri: string
+    /**
+     * This is the code obtained via the OAuth token process
+     */
+    code: string
+}

--- a/src/types/oauth_access_token.ts
+++ b/src/types/oauth_access_token.ts
@@ -14,3 +14,7 @@ export interface OAuthAccessToken {
      */
     token_type: string
 }
+
+export interface OauthAccessTokenWithRefresh extends OAuthAccessToken {
+    refresh_token: string
+}

--- a/src/types/refresh_token_grant.ts
+++ b/src/types/refresh_token_grant.ts
@@ -1,0 +1,29 @@
+/**
+ * This exchanges a refresh token obtained from the authorization code grant for a new token.
+ * Note: This is for authorization code flow only, not for client credentials type tokens.
+ * Refresh token grant is not documented officially
+ *
+ * https://osu.ppy.sh/docs/index.html#authorization-code-grant
+ */
+export interface RefreshTokenGrant {
+    /**
+     * The Client ID you received when you registered
+     */
+    client_id: number
+    /**
+     * The client secret of your application
+     */
+    client_secret: string
+    /**
+     * This must always be authorization_code (or refresh_token)
+     */
+    grant_type: "refresh_token"
+    /**
+     * This must match the redirect_uri of your app when you registered it
+     */
+    redirect_uri: string
+    /**
+     * This is the refresh token returned with a token via auth code flow
+     */
+    refresh_token: string
+}


### PR DESCRIPTION
Add functions to obtain a token via authorization code + refresh token

Note: I haven't been able to test this yet, but the only difference between these flows and the client credentials flow is a couple of different fields in the request body and response.